### PR TITLE
use `qemu_test_runner_toolchain` to run `cc_test` targets in QEMU

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//rules:cc_test_runner_toolchain.bzl", "cc_test_runner_toolchain")
 load("//rules:qemu_runner.bzl", "qemu_runner")
 
 xcode_config(name = "host_xcodes")
@@ -22,4 +23,23 @@ cc_test(
 
 qemu_runner(
     name = "qemu_runner",
+)
+
+qemu_runner(
+    name = "qemu_semihosting_runner",
+    extra_args = ["-semihosting"],
+)
+
+cc_test_runner_toolchain(
+    name = "qemu_cc_test_runner_toolchain",
+    test_runner = ":qemu_semihosting_runner",
+)
+
+toolchain(
+    name = "qemu_test_runner_toolchain",
+    target_compatible_with = [
+        "@platforms//os:none",
+    ],
+    toolchain = ":qemu_cc_test_runner_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:test_runner_toolchain_type",
 )

--- a/README.md
+++ b/README.md
@@ -32,3 +32,40 @@ bazel run \
   --platforms=//platform:lm3s6965evb \
   //example/semihosting -- <additional-args>
 ```
+
+# enabling semihosting
+
+By default, semihosting is not enabled when building targets. It can be enabled
+with bool flag `--//config:semihosting`.
+
+```sh
+bazel run \
+  --run_under=//:qemu_runner \
+  --platforms=//platform:lm3s6965evb \
+  --//config:semihosting \
+  //example/semihosting:binary
+```
+
+Alternatively, the `transition_semihosting_binary` can be used to transition a
+binary target to always enable or disable semihosting.
+
+```starlark
+transition_semihosting_binary(
+    name = "semihosting",
+    src = ":binary",
+    semihosting = "enabled",
+)
+```
+
+# running tests with `qemu`
+
+`cc_test` targets can be built for the target platform and run under emulation
+with `qemu-system-arm`.
+
+```sh
+bazel test \
+  --platforms=//platform:lm3s6965evb \
+  --extra_toolchains=//:qemu_test_runner_toolchain \
+  --//config:semihosting \
+  //...
+```

--- a/rules/cc_test_runner_toolchain.bzl
+++ b/rules/cc_test_runner_toolchain.bzl
@@ -1,0 +1,102 @@
+"""
+CcTestRunnerToolchain that executes a test binary using a custom test runner.
+
+adapted from:
+https://github.com/bazel-contrib/musl-toolchain/blob/054f2f36b4aa42d3e358cbf0afce993c9bb3b1ba/musl_cc_toolchain_config.bzl
+
+CcTestRunnerToolchain is used here:
+https://github.com/bazelbuild/bazel/blob/20cf927d8ce4e3fbd29d7bb45c5037b4fea49da8/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl#L63-L79
+"""
+
+_CcTestInfo = provider(
+    doc = "Toolchain implementation for @bazel_tools//tools/cpp:test_runner_toolchain_type",
+    fields = {
+        "get_runner": "Callback invoked by cc_test, should accept (ctx, binary_info, processed_environment, test_runner) and return a list of providers",
+        "linkopts": "Additional linkopts from an external source (e.g. toolchain)",
+        "linkstatic": "If set, force this to be linked statically (i.e. --dynamic_mode=off)",
+    },
+)
+
+_CcTestRunnerInfo = provider(
+    doc = "Test runner implementation for @bazel_tools//tools/cpp:test_runner_toolchain_type",
+    fields = {
+        "args": "kwargs to pass to the test runner function",
+        "func": "The test runner function with signature (ctx, binary_info, processed_environment, **kwargs)",
+    },
+)
+
+def _cc_test_runner_runner_func(
+        ctx,
+        binary_info,
+        processed_environment,
+        test_runner):
+    executable = ctx.actions.declare_file(ctx.label.name + "_test_runner.bash")
+
+    ctx.actions.write(
+        output = executable,
+        content = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec '{test_runner}' '{binary}' "$@"
+""".format(
+            test_runner = test_runner.files_to_run.executable.short_path,
+            binary = binary_info.executable.short_path,
+        ),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles().merge_all([
+        ctx.runfiles([test_runner.files_to_run.executable, binary_info.executable]),
+        binary_info.runfiles,
+    ] + [
+        files
+        for files in [
+            test_runner[DefaultInfo].default_runfiles,
+            test_runner[DefaultInfo].data_runfiles,
+        ]
+        if files
+    ])
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            files = binary_info.files,
+            runfiles = runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = processed_environment,
+            inherited_environment = ctx.attr.env_inherit,
+        ),
+    ]
+
+def _cc_test_runner_toolchain_impl(ctx):
+    cc_test_runner_info = _CcTestRunnerInfo(
+        args = {
+            "test_runner": ctx.attr.test_runner,
+        },
+        func = _cc_test_runner_runner_func,
+    )
+    cc_test_info = _CcTestInfo(
+        get_runner = cc_test_runner_info,
+        linkopts = [],
+        linkstatic = True,
+    )
+    return [
+        platform_common.ToolchainInfo(
+            cc_test_info = cc_test_info,
+        ),
+    ]
+
+cc_test_runner_toolchain = rule(
+    implementation = _cc_test_runner_toolchain_impl,
+    attrs = {
+        "test_runner": attr.label(
+            allow_single_file = True,
+            executable = True,
+            mandatory = True,
+            cfg = "exec",
+            doc = "Binary used to run the test executable",
+        ),
+    },
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
@@ -99,6 +100,8 @@ alias(
 
 refresh_compile_commands(
     name = "compile_commands",
+    tags = ["manual"],
+    target_compatible_with = HOST_CONSTRAINTS,
     targets = {
         "//...": "--extra_toolchains=@llvm_toolchain//:all",
     },


### PR DESCRIPTION
Add a CcTestRunnerToolchain that is used to run `cc_test` targets in
QEMU. When using this CcTestRunnerToolchain, semihosting must be enabled
-- it is not automatically enabled for building the `cc_test` target.

This is because the configuration must by applied to the underlying
`lm3s6965evb` toolchain (to select startup code that enables
semihosting) which is selected by toolchain registration when using
`--platforms=//platform:lm3s6965evb`.

The underlying QEMU runner of the test runner toolchain
(`//:qemu_runner`) always uses semihosting, as it would be meaning less
otherwise -- the binaries must complete and test success is determined
by the return code.

```sh
bazel test \
  --platforms=//platform:lm3s6965evb \
  --extra_toolchains=//:qemu_test_runner_toolchain \
  --//config:semihosting \
  //:dummy_test
```

Change-Id: I4b78fe92fd5cef08271223ede19c44d0f94b18d4