### PR TITLE
enable QEMU monitor output by default

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -123,14 +123,14 @@ llvm.toolchain(
 )
 use_repo(llvm, "llvm_toolchain")
 
-register_toolchains("@llvm_toolchain//:all")
-
 arm_toolchain = use_extension("@toolchains_arm_gnu//:extensions.bzl", "arm_toolchain")
 arm_toolchain.arm_none_eabi(version = "13.2.1")
 use_repo(arm_toolchain, "arm_none_eabi")
 
 register_toolchains(
+    "@llvm_toolchain//:all",
     "//toolchain:all",
+    "//:qemu_test_runner_toolchain",
     dev_dependency = True,
 )
 

--- a/dummy_test.cpp
+++ b/dummy_test.cpp
@@ -1,1 +1,6 @@
-auto main() -> int {}
+#include <cstdio>
+
+auto main() -> int
+{
+  ::printf("PASSED\n");
+}

--- a/example/semihosting/README.md
+++ b/example/semihosting/README.md
@@ -4,7 +4,7 @@ run with
 bazel run \
   --platforms=//platform:lm3s6965evb \
   --run_under=//:qemu_runner \
-  --//config:semihosting=True \
+  --//config:semihosting \
   //example/semihosting:binary
 ```
 

--- a/rules/qemu_runner.bzl
+++ b/rules/qemu_runner.bzl
@@ -30,10 +30,10 @@ def _impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
 
     fixed_args = [
+        "-gdb tcp::1234",
         "-display none",
-    ]
-    if ctx.attr.gdb:
-        fixed_args.append("-gdb " + ctx.attr.gdb)
+        "-monitor stdio",
+    ] if ctx.attr.enable_default_args else []
     if cfg.semihosting:
         fixed_args.append("-semihosting")
     if cfg.machine:
@@ -93,12 +93,13 @@ exec $(rlocation {qemu_system_arm}) "${{args[@]}}"
 qemu_runner = rule(
     implementation = _impl,
     attrs = {
-        "gdb": attr.string(
-            default = "tcp::1234",
-            doc = "QEMU gdb port",
-        ),
         "extra_args": attr.string_list(
+            default = [],
             doc = "Extra arguments to pass to QEMU",
+        ),
+        "enable_default_args": attr.bool(
+            default = True,
+            doc = "Enable default arguments passed to QEMU",
         ),
         "_qemu_system_arm": attr.label(
             default = "@qemu-system-arm",


### PR DESCRIPTION
```sh
❯  bazel test \
  --platforms=//platform:lm3s6965evb \
  --//config:semihosting \
  --test_output=all \
  //...

...

INFO: From Testing //:dummy_test
==================== Test output for //:dummy_test:
QEMU 9.2.4 monitor - type 'help' for more information
(qemu) PASSED
================================================================================
//:dummy_test                                                   (cached) PASSED in 0.4s
```

Change-Id: I8df779a076a88909b4ca5373ac911d7ad30e2f9f