### PR TITLE
define `transition_config_{binary,test}` rules

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,1 +1,2 @@
-USE_BAZEL_VERSION=8.x
+# use a fixed version to avoid checking online for the latest version
+USE_BAZEL_VERSION=8.3.1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//rules:cc_test_runner_toolchain.bzl", "cc_test_runner_toolchain")
 load("//rules:qemu_runner.bzl", "qemu_runner")
+load("//rules:transitions.bzl", "transition_config_test")
 
 xcode_config(name = "host_xcodes")
 
@@ -14,11 +15,6 @@ filegroup(
     name = "tidy-config",
     srcs = [".clang-tidy"],
     visibility = [":__subpackages__"],
-)
-
-cc_test(
-    name = "dummy_test",
-    srcs = ["dummy_test.cpp"],
 )
 
 qemu_runner(
@@ -42,4 +38,16 @@ toolchain(
     ],
     toolchain = ":qemu_cc_test_runner_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:test_runner_toolchain_type",
+)
+
+cc_test(
+    name = "dummy_test",
+    srcs = ["dummy_test.cpp"],
+)
+
+transition_config_test(
+    name = "dummy_test.lm3s6965evb",
+    src = ":dummy_test",
+    platform = "//platform:lm3s6965evb",
+    semihosting = "enabled",
 )

--- a/example/semihosting/BUILD.bazel
+++ b/example/semihosting/BUILD.bazel
@@ -1,14 +1,24 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//rules:transitions.bzl", "transition_semihosting_binary")
+load("//rules:transitions.bzl", "transition_config_binary")
 
 cc_binary(
     name = "binary",
     srcs = ["main.cpp"],
-    tags = ["manual"],
 )
 
-transition_semihosting_binary(
+# `transition_config_binary` must be run with `--run_under=//:qemu_runner` if
+# using a non-host platform since we cannot apply a transition to the
+# `--run_under` option.
+
+transition_config_binary(
     name = "semihosting",
     src = ":binary",
+    semihosting = "enabled",
+)
+
+transition_config_binary(
+    name = "semihosting.lm3s6965evb",
+    src = ":binary",
+    platform = "//platform:lm3s6965evb",
     semihosting = "enabled",
 )

--- a/example/semihosting/README.md
+++ b/example/semihosting/README.md
@@ -14,5 +14,12 @@ or
 bazel run \
   --platforms=//platform:lm3s6965evb \
   --run_under=//:qemu_runner \
-  //example/semihosting
+  //example/semihosting:semihosting
+```
+or
+
+```sh
+bazel run \
+  --run_under=//:qemu_runner    \
+  //example/semihosting:semihosting.lm3s6965evb
 ```

--- a/example/semihosting/main.cpp
+++ b/example/semihosting/main.cpp
@@ -2,6 +2,6 @@
 
 auto main() -> int
 {
-   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
   ::printf("hello world!\n");
 }

--- a/rules/qemu_runner.bzl
+++ b/rules/qemu_runner.bzl
@@ -69,6 +69,8 @@ binary="$1"
 args=({fixed_args} "-device" "loader,file=$binary")
 args+=("${{@:2}}")
 
+[[ -n "${{QEMU_MACHINE:-}}" ]] && args+=("-machine" "$QEMU_MACHINE")
+
 exec $(rlocation {qemu_system_arm}) "${{args[@]}}"
 """.format(
             fixed_args = " ".join(fixed_args),

--- a/rules/transitions.bzl
+++ b/rules/transitions.bzl
@@ -2,20 +2,39 @@
 Rule to transition the semihosting configuration of a binary
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_cc//cc/common:debug_package_info.bzl", "DebugPackageInfo")
 
-_semihosting_transition = transition(
-    implementation = lambda _settings, attr: {
-        "//config:semihosting": {"enabled": True, "disabled": False}[attr.semihosting],
-    },
-    inputs = [],
+def _config_transition_impl(settings, attr):
+    out = {} | settings
+
+    if attr.semihosting:
+        out["//config:semihosting"] = attr.semihosting == "enabled"
+
+    if attr.platform:
+        out["//command_line_option:platforms"] = [attr.platform]
+
+    if attr.extra_toolchains:
+        out["//command_line_option:extra_toolchains"] = attr.extra_toolchains
+
+    return out
+
+_config_transition = transition(
+    implementation = _config_transition_impl,
+    inputs = [
+        "//config:semihosting",
+        "//command_line_option:platforms",
+        "//command_line_option:extra_toolchains",
+    ],
     outputs = [
         "//config:semihosting",
+        "//command_line_option:platforms",
+        "//command_line_option:extra_toolchains",
     ],
 )
 
-def _transition_semihosting_binary_impl(ctx):
+def _transition_config_binary_impl(ctx):
     target = ctx.attr.src
     default_info = target[DefaultInfo]
 
@@ -30,10 +49,27 @@ def _transition_semihosting_binary_impl(ctx):
         target_file = binary,
     )
 
+    # `//config:machine` doesn't get propagated to the `run_under` arg so we
+    # pass the machine option via RunEnvironmentInfo
+    machine = ctx.attr._machine[BuildSettingInfo].value
+
+    env = {
+        "QEMU_MACHINE": machine,
+    } if machine else {}
+
+    inherit_env = ctx.attr.inherit_env
+    if RunEnvironmentInfo in target:
+        env = target[RunEnvironmentInfo].environment | env
+        inherit_env = target[RunEnvironmentInfo].inherited_environment
+
     return [
         DefaultInfo(
             executable = out,
             runfiles = runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = env,
+            inherited_environment = inherit_env,
         ),
     ] + [
         target[provider]
@@ -42,28 +78,47 @@ def _transition_semihosting_binary_impl(ctx):
             DebugPackageInfo,
             OutputGroupInfo,
             InstrumentedFilesInfo,
-            RunEnvironmentInfo,
         ]
         if provider in target
     ]
 
-transition_semihosting_binary = rule(
-    implementation = _transition_semihosting_binary_impl,
-    cfg = _semihosting_transition,
-    attrs = {
-        "src": attr.label(
-            mandatory = True,
-            providers = [CcInfo],
-            doc = "The binary to transition",
-        ),
-        "semihosting": attr.string(
-            values = ["enabled", "disabled"],
-            mandatory = True,
-            doc = "Enable or disable semihosting",
-        ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
-    },
+_common_attrs = {
+    "src": attr.label(
+        mandatory = True,
+        providers = [CcInfo],
+        doc = "The binary to transition",
+    ),
+    "inherit_env": attr.string_list(
+        doc = "Environment variables to inherit",
+    ),
+    "semihosting": attr.string(
+        values = ["enabled", "disabled"],
+        doc = "Enable or disable semihosting or leave it unchanged if `None`",
+    ),
+    "platform": attr.label(
+        doc = "Target platform for the binary",
+    ),
+    "extra_toolchains": attr.label_list(
+        doc = "Extra toolchains to use with the binary",
+    ),
+    "_machine": attr.label(
+        default = "//config:machine",
+    ),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}
+
+transition_config_binary = rule(
+    implementation = _transition_config_binary_impl,
+    cfg = _config_transition,
+    attrs = _common_attrs,
     executable = True,
+)
+
+transition_config_test = rule(
+    implementation = _transition_config_binary_impl,
+    cfg = _config_transition,
+    attrs = _common_attrs,
+    test = True,
 )


### PR DESCRIPTION
`transition_config_binary` and `transition_config_test` are used to
transition a `cc_binary` or `cc_test` target to a specified platform,
removing the need to specify the platform at the command line. With
`cc_binary`, the corresponding binary still need to be run with
`--run_under=//:qemu_runner` if the target platform differs from the
host platform -- this is because `--run_under` depends on the exec
configuration and is not a valid build setting for transitions of a
target.

`transition_config_{binary,test}` have the following attributes:
`src`: `label`
The binary target to transition.
  
`inherit_env`: `string_list`
Environment variables to inherit when running the transitioned binary.

`semihosting`: `string | None`
 Enable or disable semihosting, or leave unchanged if `None`.
  
`platform`: `label`
 Target platform for the binary.

`extra_toolchains`: `label_list`
 Extra toolchains to use when building the binary. May also include
 extra toolchains to use when running the binary if it is a test.

`semihosting` defaults to `None` for `transition_config_binary`
and `"enabled"` for `transition_config_test`.

Note that the `//:qemu_test_runner_toolchain` can be set in
`extra_toolchains` for test targets as an alternative, or to override,
registered toolchains.

The QEMU machine is encoded in the transitioned target via
RunEnvironmentInfo, which is then read by the QemuRunner.

These rules allow flagless builds for building and testing (but not
running):

```starlark
transition_config_binary(
    name = "my_binary.lm3s6965evb",
    src = ":my_binary",
    platform = "//platform:lm3s6965evb",
    semihosting = "enabled",
)

transition_config_test(
    name = "my_test.lm3s6965evb",
    src = ":my_test",
    platform = "//platform:lm3s6965evb",
)
```

Change-Id: Id53512383255bc23e5f3216b9bd39708687f3d3e