### PR TITLE
add `binary_log_test` rule

### DIFF
--- a/example/semihosting/BUILD.bazel
+++ b/example/semihosting/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//rules:binary_log.bzl", "binary_log")
+load("//rules:binary_log.bzl", "binary_log", "binary_log_test")
 load("//rules:transitions.bzl", "transition_config_binary")
 
 cc_binary(
@@ -28,4 +28,10 @@ binary_log(
     name = "semihosting.lm3s6965evb.log",
     src = "semihosting.lm3s6965evb",
     run_under = "//:qemu_runner",
+)
+
+binary_log_test(
+    name = "semihosting.lm3s6965evb.test",
+    expected_stdout = "stdout",
+    logs = ":semihosting.lm3s6965evb.log",
 )

--- a/example/semihosting/stdout
+++ b/example/semihosting/stdout
@@ -1,0 +1,2 @@
+QEMU 9.2.4 monitor - type 'help' for more information
+(qemu) hello world!


### PR DESCRIPTION
`binary_log_test` is a rule that compares the log output of a binary to
files containing the expected content for stdout and stderr.

Change-Id: Ia37c2609c875b6ea5769707f98e62a7b2ba686b6