### PR TITLE
remove default gdb server args from QEMU runner

### DIFF
--- a/example/minimal/README.md
+++ b/example/minimal/README.md
@@ -18,7 +18,7 @@ In another terminal, run the target with qemu:
     --run_under=//:qemu_runner \
     -c dbg \
     //example/minimal -- \
-    -S
+    -s -S
 ```
 
 Connect with gdb:

--- a/rules/qemu_runner.bzl
+++ b/rules/qemu_runner.bzl
@@ -30,7 +30,6 @@ def _impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
 
     fixed_args = [
-        "-gdb tcp::1234",
         "-display none",
         "-monitor stdio",
     ] if ctx.attr.enable_default_args else []


### PR DESCRIPTION
Change-Id: Ie9846e81259a76c51db6695f915ad2d35050c3e2